### PR TITLE
Reduce docker image space

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -14,7 +14,7 @@ runs:
       uses: astral-sh/setup-uv@v6
       with:
         version: "0.6.x"
-        python-version: 3.12
+        python-version: 3.13
 
     - name: Install dependencies
       shell: bash

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -11,7 +11,7 @@ ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=never \
     UV_PYTHON=python3.12 \
-    PATH="/director5/.venv/bin:$PATH"
+    UV_PROJECT_ENVIRONMENT="/venv"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libpq-dev \

--- a/dev/docker/compose.yaml
+++ b/dev/docker/compose.yaml
@@ -37,7 +37,6 @@ services:
       - director_net
     volumes:
       - ../../:/director5
-      - /director5/.venv
     depends_on:
       - redis
 
@@ -56,7 +55,6 @@ services:
     volumes:
       - ../../:/director5
       - ../../docker/storage/:/data
-      - /director5/.venv
     depends_on:
       - postgres
     entrypoint:
@@ -75,7 +73,6 @@ services:
     volumes:
       - ../../:/director5
       - ../../docker/storage/:/data
-      - /director5/.venv
       - /var/run/docker.sock:/var/run/docker.sock
     entrypoint:
       - "/director5/dev/docker/docker-entrypoint.sh"
@@ -92,7 +89,6 @@ services:
       - director_net
     volumes:
       - ../../:/director5
-      - /director5/.venv
     depends_on:
       - django
     entrypoint:

--- a/dev/docker/docker-entrypoint.sh
+++ b/dev/docker/docker-entrypoint.sh
@@ -2,12 +2,10 @@
 
 set -e
 
-uv sync
-
 if [ "$1" = "django" ]; then
-    python manage.py migrate --noinput
+    uv run python manage.py migrate --noinput
     # hand control over to django to handle SIGTERM
-    exec python manage.py runserver 0.0.0.0:8080
+    exec uv run python manage.py runserver 0.0.0.0:8080
 elif [ "$1" = "tailwind" ]; then
     static="manager/director/static/tailwind"
     exec dev/tailwind/tailwindcss -i $static/input.css -o $static/build.css --config dev/tailwind/tailwind.config.js --watch --poll


### PR DESCRIPTION
# Motivation
This reduces the space needed for the dev setup by avoiding having separate virtual environments for every compose service, and instead storing one virtual environment in the docker image itself.
Additionally, this approach still allows usage of `uv` outside the docker container itself, so nothing is lost with this approach.

# Possible Problems
This no longer puts the virtual environment on `PATH`, so usage of `uv run` will be necessary.