### PR TITLE
Reduce boilerplate by including pingable appservers in operations

### DIFF
--- a/manager/director/apps/sites/tasks.py
+++ b/manager/director/apps/sites/tasks.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from celery import shared_task
 from django.conf import settings
 
@@ -10,14 +8,7 @@ from .operations import auto_run_operation_wrapper
 
 @shared_task
 def create_site(operation_id: int) -> None:
-    scope: dict[str, Any] = {}
-
-    with auto_run_operation_wrapper(operation_id, scope) as wrapper:
-        wrapper.register_action(
-            "Pinging appservers",
-            actions.find_pingable_appservers,
-            user_recoverable=True,
-        )
+    with auto_run_operation_wrapper(operation_id) as wrapper:
         wrapper.register_action(
             "Building Docker image",
             actions.build_docker_image,
@@ -28,17 +19,9 @@ def create_site(operation_id: int) -> None:
 
 @shared_task
 def delete_site(operation_id: int) -> None:
-    scope: dict[str, Any] = {}
-
     site = Site.objects.get(operation__id=operation_id)
 
-    with auto_run_operation_wrapper(operation_id, scope) as wrapper:
-        wrapper.register_action(
-            "Pinging appservers",
-            actions.find_pingable_appservers,
-            user_recoverable=True,
-        )
-
+    with auto_run_operation_wrapper(operation_id) as wrapper:
         if settings.SITE_DELETION_REMOVE_FILES:
             wrapper.register_action("Deleting site files", actions.delete_site_files)
         if settings.SITE_DELETION_REMOVE_DATABASE:


### PR DESCRIPTION
Essentially, this gets rid of the `scope = {}` nonsense and the (essentially required) `find_pingable_appservers` action.
This also makes the project easier to type check.